### PR TITLE
Added ability to Freeze Headers #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ var exportDefinition = new SpreadsheetConfiguration<SimpleExportData>
     RenderSubTitle = true,
     DocumentSubTitle = "Showing the full options",
     ExportData = GetSampleExportData(100),
-    WorksheetName = "Sample"
+    WorksheetName = "Sample",
+    FreezePanes = true
 };
 var fileContent = exportGenerator.CreateSingleSheetSpreadsheet(exportDefinition);
 System.IO.File.WriteAllBytes("Sample.xlsx", fileContent);
@@ -74,4 +75,5 @@ This package is primarily geared towards the exporting of lists of objects into 
 * The ability to have a heading and subheading if desired
 * Data type formatting for Date & Currency fields
 * Auto-fit of all columns for display
+* The ability to freeze the header columns into a freeze pane for single sheet, or multi-sheet exports
 * Support for Curreny, Date, F0, F1, and F2 fixed date formats

--- a/samples/NetCore.Utilities.SpreadsheetExample/Program.cs
+++ b/samples/NetCore.Utilities.SpreadsheetExample/Program.cs
@@ -24,7 +24,8 @@ namespace NetCore.Utilities.SpreadsheetExample
                 RenderSubTitle = true,
                 DocumentSubTitle = "Showing the full options",
                 ExportData = GetSampleExportData(100),
-                WorksheetName = "Sample"
+                WorksheetName = "Sample",
+                FreezeHeaders = true
             };
             var fileContent = exportGenerator.CreateSingleSheetSpreadsheet(exportDefinition);
             System.IO.File.WriteAllBytes("Sample.xlsx", fileContent);
@@ -36,6 +37,7 @@ namespace NetCore.Utilities.SpreadsheetExample
                 {
                     config.DocumentTitle = "Lots of data";
                     config.RenderTitle = true;
+                    config.FreezeHeaders = true;
                 });
 
             var multiFileContent = exportGenerator.CreateMultiSheetSpreadsheet(multiSheetDefinition);

--- a/src/NetCore.Utilities.Spreadsheet/SpreadsheetConfiguration.cs
+++ b/src/NetCore.Utilities.Spreadsheet/SpreadsheetConfiguration.cs
@@ -58,6 +58,11 @@ public interface ISpreadsheetConfiguration
     /// Controls if the columns are auto-sized
     /// </summary>
     public bool AutoSizeColumns { get; set; }
+
+    /// <summary>
+    /// if set to true the header(s) will be frozen
+    /// </summary>
+    public bool FreezeHeaders { get; set; }
 }
 /// <inheritdoc />
 /// <typeparam name="TRecord">The type to be exported</typeparam>
@@ -120,6 +125,11 @@ public class SpreadsheetConfiguration<T> : ISpreadsheetConfiguration<T> where T 
 
     /// <inheritdoc />
     public bool AutoSizeColumns { get; set; } = true;
+
+    /// <summary>
+    /// if set to true the header(s) will be frozen
+    /// </summary>
+    public bool FreezeHeaders { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
- Fixes #49 

This change introduces a new Spreadsheet configuration item that allows you to "FreezeHeaders" on an particular sheet of export.  This process will calculate, based on the configured headers, what rows should be frozen and then adds a view for pane detection.

This has been tested in the following configurations, and the "samples" updated to show some differences.
* Single Sheet Export
  *  No Title or Sub Title
  * Title and No Sub Title
  * Both Title and Sub Title
* Multi Sheet Export
  * All above permutations